### PR TITLE
Error unzipping 7-zip in tools/creat_coremp135_buidlroot_image.sh

### DIFF
--- a/tools/creat_coremp135_buidlroot_image.sh
+++ b/tools/creat_coremp135_buidlroot_image.sh
@@ -18,7 +18,7 @@ clone_buildroot() {
     [ -d 'CoreMP135_buildroot' ] || git clone https://github.com/m5stack/CoreMP135_buildroot.git
     pushd CoreMP135_buildroot
     [ -f 'dl.7z' ] || wget https://github.com/m5stack/CoreMP135_buildroot/releases/download/m5stack%2F2024.5.1/dl.7z
-    [ -d 'dl' ] || 7z e dl.7z
+    [ -d 'dl' ] || 7z x dl.7z
     popd
 }
 


### PR DESCRIPTION
## overview:
Error occurs in tools/creat_coremp135_buidlroot_image.sh.

## Cause of a problem

./creat_coremp135_buidlroot_image.sh

### Before correction
``` 
    [ -d 'dl' ] || 7z e dl.7z
```
7-zip ignores directories within the archive and unzips all files into the same directory. This causes the above error.

### My Revised
``` 
    [ -d 'dl' ] || 7z x dl.7z
```

x extracts the archive while preserving the directory, so this is usually used.

### Error symptoms

```
$ cd tools/
$ ./creat_coremp135_buidlroot_image.sh

Extracting archive: dl.7z
--
Path = dl.7z
Type = 7z
Physical Size = 1523684957
Headers Size = 74271
Method = LZMA2:24
Solid = +
Blocks = 1


Would you like to replace the existing file:
  Path:     ./.lock
  Size:     0 bytes
  Modified: 2024-04-12 16:55:02
with the file from archive:
  Path:     arm-trusted-firmware/.lock
  Size:     0 bytes
  Modified: 2024-04-12 16:55:02
? (Y)es / (N)o / (A)lways / (S)kip all / A(u)to rename all / (Q)uit? ^
````

