### PR TITLE
Kil getty first and unload modules

### DIFF
--- a/board/m5stack/overlay/etc/init.d/S02modules
+++ b/board/m5stack/overlay/etc/init.d/S02modules
@@ -33,7 +33,7 @@ start() {
 stop() {
 	printf 'Stopping %s: ' "$MODULES"
 
-#	load_unload unload
+	load_unload unload
 
 	echo 'OK'
 }

--- a/board/m5stack/overlay/etc/init.d/S50agetty
+++ b/board/m5stack/overlay/etc/init.d/S50agetty
@@ -1,11 +1,12 @@
 #!/bin/sh
 
 start() {
-    usr/local/m5stack/lt8618sxb_mcu_config &> /dev/null &
-	/sbin/agetty  --noclear tty1 linux 2>&1 > /dev/null &
+	usr/local/m5stack/lt8618sxb_mcu_config &> /dev/null &
+	/sbin/agetty --noclear tty1 linux 2>&1 > /dev/null &
+	/sbin/agetty -o '-p -- \\u' --keep-baud ttyGS0 2>&1 > /dev/null &
 }
 stop() {
-	echo "no" > /dev/null
+	killall -9 agetty
 }
 restart() {
 	stop

--- a/board/m5stack/overlay/etc/inittab
+++ b/board/m5stack/overlay/etc/inittab
@@ -30,7 +30,6 @@ null::sysinit:/bin/ln -sf /proc/self/fd/2 /dev/stderr
 
 # Put a getty on the serial port
 console::respawn:/sbin/getty -L console 0 vt100 # GENERIC_SERIAL
-console::respawn:/sbin/getty -L ttyGS0 115200 vt100 # GENERIC_SERIAL
 
 # Stuff to do for the 3-finger salute
 #::ctrlaltdel:/sbin/reboot


### PR DESCRIPTION
Previous implementation of module unload did not take care of getty blocking serial devices.
Move serial getty to S50agetty and kill it when needed.

Fixes: #3